### PR TITLE
fix: Add missing default

### DIFF
--- a/package/src/index.d.ts
+++ b/package/src/index.d.ts
@@ -102,7 +102,7 @@ export declare enum Regions {
     Brazil = 'br',
 }
 
-export class {
+export default class {
     private _parsebody(body: any): any;
     private _parseresponse(req: any): APIResponse;
     private _validate(input: any): any;


### PR DESCRIPTION
In Typescript projects, "export class" cannot be compiled and must be changed to "export default class". Below is the error I am getting and the source code, and I fixed it in this PR.  Thank you ❤️ 

# Source code (src/index.ts)

```ts
import HenrikDevValorantAPI from 'unofficial-valorant-api';

const run = async () => {
    const api = new HenrikDevValorantAPI();
}

run().catch(err => console.error(err))
```

# Error

```
> ts-node src/index.ts

/Users/epq/project/Private/valorant-stats/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
src/index.ts:4:21 - error TS2351: This expression is not constructable.
  Type 'typeof import("/Users/epq/project/Private/valorant-stats/node_modules/unofficial-valorant-api/src/index")' has no construct signatures.

4     const api = new HenrikDevValorantAPI();
                      ~~~~~~~~~~~~~~~~~~~~

    at createTSError (/Users/epq/project/Private/valorant-stats/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/Users/epq/project/Private/valorant-stats/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/Users/epq/project/Private/valorant-stats/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/Users/epq/project/Private/valorant-stats/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/Users/epq/project/Private/valorant-stats/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/epq/project/Private/valorant-stats/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12) {
  diagnosticCodes: [ 2351 ]
}
```