### PR TITLE
fix: Change declare enum to type

### DIFF
--- a/package/src/index.d.ts
+++ b/package/src/index.d.ts
@@ -1,106 +1,87 @@
-export declare enum Episodes {
-    Episode1Act1 = 'e1a1',
-    Episode1Act2 = 'e1a2',
-    Episode1Act3 = 'e1a3',
-    Episode2Act1 = 'e2a1',
-    Episode2Act2 = 'e2a2',
-    Episode2Act3 = 'e2a3',
-    Episode3Act1 = 'e3a1',
-    Episode3Act2 = 'e3a2',
-    Episode3Act3 = 'e3a3',
-    Episode4Act1 = 'e4a1',
-    Episode4Act2 = 'e4a2',
-    Episode4Act3 = 'e4a3',
-    Episode5Act1 = 'e5a1',
-    Episode5Act2 = 'e5a2',
-    Episode5Act3 = 'e5a3',
-}
+export type Episodes =
+    'e1a1' |
+    'e1a2' |
+    'e1a3' |
+    'e2a1' |
+    'e2a2' |
+    'e2a3' |
+    'e3a1' |
+    'e3a2' |
+    'e3a3' |
+    'e4a1' |
+    'e4a2' |
+    'e4a3' |
+    'e5a1' |
+    'e5a2' |
+    'e5a3';
 
-export declare enum Modes {
-    Escalation = 'escalation',
-    SpikeRush = 'spikerush',
-    Deathmatch = 'deathmatch',
-    Competitive = 'competitive',
-    Unrated = 'unrated',
-    Replication = 'replication',
-    Custom = 'custom',
-    NewMap = 'newmap',
-    Snowball = 'snowball',
-}
+export type Modes =
+    'escalation' |
+    'spikerush' |
+    'deathmatch' |
+    'competitive' |
+    'unrated' |
+    'replication' |
+    'custom' |
+    'newmap' |
+    'snowball';
 
-export declare enum Maps {
-    Ascent = 'ascent',
-    Split = 'split',
-    Fracture = 'fracture',
-    Bind = 'bind',
-    Breeze = 'breeze',
-    Icebox = 'icebox',
-    Haven = 'haven',
-    Pearl = 'pearl',
-}
+export type Maps =
+    'ascent' |
+    'split' |
+    'fracture' |
+    'bind' |
+    'breeze' |
+    'icebox' |
+    'haven' |
+    'pearl';
 
-export declare enum CCRegions {
-    EnglishGB = 'en-gb',
-    EnglishUS = 'en-us',
-    Spanish = 'es-es',
-    Mexican = 'es-mx',
-    French = 'fr-fr',
-    Italian = 'it-it',
-    Japanese = 'ja-jp',
-    Korean = 'ko-kr',
-    Portuguese = 'pt-br',
-    Russian = 'ru-ru',
-    Turkish = 'tr-tr',
-    Vietnamese = 'vi-vn',
-}
+export type CCRegions =
+    'en-gb' |
+    'en-us' |
+    'es-es' |
+    'es-mx' |
+    'fr-fr' |
+    'it-it' |
+    'ja-jp' |
+    'ko-kr' |
+    'pt-br' |
+    'ru-ru' |
+    'tr-tr' |
+    'vi-vn';
 
-export declare enum Locales {
-    Arabic = 'ar-AE',
-    German = 'de-DE',
-    EnglishGB = 'en-GB',
-    EnglishUS = 'en-US',
-    Spanish = 'es-ES',
-    Mexican = 'es-MX',
-    French = 'fr-FR',
-    Indonesian = 'id-ID',
-    Italian = 'it-IT',
-    Japanese = 'ja-JP',
-    Korean = 'ko-KR',
-    Polish = 'pl-PL',
-    Portuguese = 'pt-BR',
-    Russian = 'ru-RU',
-    Thailand = 'th-TH',
-    Turkish = 'tr-TR',
-    Vietnamese = 'vi-VN',
-    Czech = 'zn-CN',
-    Taiwanese = 'zn-TW',
-}
+export type Locales =
+    'ar-AE' |
+    'de-DE' |
+    'en-GB' |
+    'en-US' |
+    'es-ES' |
+    'es-MX' |
+    'fr-FR' |
+    'id-ID' |
+    'it-IT' |
+    'ja-JP' |
+    'ko-KR' |
+    'pl-PL' |
+    'pt-BR' |
+    'ru-RU' |
+    'th-TH' |
+    'tr-TR' |
+    'vi-VN' |
+    'zn-CN' |
+    'zn-TW';
 
-export declare enum RawTypes {
-    CompetitiveUpdates = 'competitiveupdates',
-    MMR = 'mmr',
-    MatchDetails = 'matchdetails',
-    MatchHistory = 'matchhistory',
-}
+export type RawTypes =
+    'competitiveupdates' |
+    'mmr' |
+    'matchdetails' |
+    'matchhistory';
 
-export declare enum MMRVersions {
-    Version1 = 'v1',
-    Version2 = 'v2',
-}
+export type MMRVersions = 'v1' | 'v2';
 
-export declare enum LeaderboardVersions {
-    Version1 = 'v1',
-    Version2 = 'v2',
-}
+export type LeaderboardVersions = 'v1' | 'v2';
 
-export declare enum Regions {
-    Europe = 'eu',
-    NorthAmerica = 'na',
-    Korea = 'kr',
-    Asia = 'ap',
-    LatinAmerica = 'latam',
-    Brazil = 'br',
-}
+export type Regions = 'eu' | 'na' | 'kr' | 'ap' | 'latam' | 'br';
 
 export class {
     private _parsebody(body: any): any;


### PR DESCRIPTION
If #48 is not merged, it will not compile. I thought about putting it in one PR but splitting it into two PRs in case I could discuss this change with you.

---

Using "declare enum" gives an undefined error. It can also define an enum on the js side, but using "type" is better. d.ts can only define types/interfaces (in other words, inputs and outputs), not new enums. Have you tried this API by creating a Typescript project? Also, this change is just a fix for broken code, not a breaking change.

# Before

## Source code (src/index.ts)

```ts
import HenrikDevValorantAPI, { Regions } from 'unofficial-valorant-api';

const run = async () => {
    const api = new HenrikDevValorantAPI();
    console.info(await api.getMatches({ region: Regions.Asia, name: '...', tag: '...' }));
}

run().catch(err => console.error(err))
```

## Error

```
> ts-node src/index.ts

TypeError: Cannot read properties of undefined (reading 'Asia')
    at /Users/epq/project/Private/valorant-stats/src/index.ts:5:57
    at Generator.next (<anonymous>)
    at /Users/epq/project/Private/valorant-stats/src/index.ts:31:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/epq/project/Private/valorant-stats/src/index.ts:27:12)
    at run (/Users/epq/project/Private/valorant-stats/src/index.ts:3:24)
    at Object.<anonymous> (/Users/epq/project/Private/valorant-stats/src/index.ts:8:1)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Module.m._compile (/Users/epq/project/Private/valorant-stats/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
```

# After

## Source code (src/index.ts)

```ts
import HenrikDevValorantAPI from 'unofficial-valorant-api';

const run = async () => {
    const api = new HenrikDevValorantAPI();
    console.info(await api.getMatches({ region: 'ap', name: '...', tag: '...' }));
}

run().catch(err => console.error(err))
```